### PR TITLE
fix: copy constraints issues causing memory grow

### DIFF
--- a/constraint/bls12-377/r1cs.go
+++ b/constraint/bls12-377/r1cs.go
@@ -103,7 +103,8 @@ func (cs *R1CS) AddStaticConstraints(key string, constraintPos int, finished boo
 		count := len(cs.StaticConstraints[key].StaticR1CS)
 		inputConstraintCount := cs.StaticConstraints[key].InputConstraintsThreshold
 		// constraintPos - count is the start constraint of the inputs
-		inputConstraints := cs.Constraints[constraintPos-count : constraintPos-count+inputConstraintCount]
+		inputConstraints := make([]constraint.R1C, inputConstraintCount)
+		copy(inputConstraints, cs.Constraints[constraintPos-count:constraintPos-count+inputConstraintCount])
 		shift := nbVariables - cs.StaticConstraints[key].NbVariables
 		input := constraint.NewLazyInputs(key, inputConstraints, constraintPos-count, count, len(expressions), shift)
 		cs.LazyCons = append(cs.LazyCons, input)

--- a/constraint/bls12-381/r1cs.go
+++ b/constraint/bls12-381/r1cs.go
@@ -103,7 +103,8 @@ func (cs *R1CS) AddStaticConstraints(key string, constraintPos int, finished boo
 		count := len(cs.StaticConstraints[key].StaticR1CS)
 		inputConstraintCount := cs.StaticConstraints[key].InputConstraintsThreshold
 		// constraintPos - count is the start constraint of the inputs
-		inputConstraints := cs.Constraints[constraintPos-count : constraintPos-count+inputConstraintCount]
+		inputConstraints := make([]constraint.R1C, inputConstraintCount)
+		copy(inputConstraints, cs.Constraints[constraintPos-count:constraintPos-count+inputConstraintCount])
 		shift := nbVariables - cs.StaticConstraints[key].NbVariables
 		input := constraint.NewLazyInputs(key, inputConstraints, constraintPos-count, count, len(expressions), shift)
 		cs.LazyCons = append(cs.LazyCons, input)

--- a/constraint/bls24-315/r1cs.go
+++ b/constraint/bls24-315/r1cs.go
@@ -103,7 +103,8 @@ func (cs *R1CS) AddStaticConstraints(key string, constraintPos int, finished boo
 		count := len(cs.StaticConstraints[key].StaticR1CS)
 		inputConstraintCount := cs.StaticConstraints[key].InputConstraintsThreshold
 		// constraintPos - count is the start constraint of the inputs
-		inputConstraints := cs.Constraints[constraintPos-count : constraintPos-count+inputConstraintCount]
+		inputConstraints := make([]constraint.R1C, inputConstraintCount)
+		copy(inputConstraints, cs.Constraints[constraintPos-count:constraintPos-count+inputConstraintCount])
 		shift := nbVariables - cs.StaticConstraints[key].NbVariables
 		input := constraint.NewLazyInputs(key, inputConstraints, constraintPos-count, count, len(expressions), shift)
 		cs.LazyCons = append(cs.LazyCons, input)

--- a/constraint/bls24-317/r1cs.go
+++ b/constraint/bls24-317/r1cs.go
@@ -103,7 +103,8 @@ func (cs *R1CS) AddStaticConstraints(key string, constraintPos int, finished boo
 		count := len(cs.StaticConstraints[key].StaticR1CS)
 		inputConstraintCount := cs.StaticConstraints[key].InputConstraintsThreshold
 		// constraintPos - count is the start constraint of the inputs
-		inputConstraints := cs.Constraints[constraintPos-count : constraintPos-count+inputConstraintCount]
+		inputConstraints := make([]constraint.R1C, inputConstraintCount)
+		copy(inputConstraints, cs.Constraints[constraintPos-count:constraintPos-count+inputConstraintCount])
 		shift := nbVariables - cs.StaticConstraints[key].NbVariables
 		input := constraint.NewLazyInputs(key, inputConstraints, constraintPos-count, count, len(expressions), shift)
 		cs.LazyCons = append(cs.LazyCons, input)

--- a/constraint/bn254/r1cs.go
+++ b/constraint/bn254/r1cs.go
@@ -103,7 +103,8 @@ func (cs *R1CS) AddStaticConstraints(key string, constraintPos int, finished boo
 		count := len(cs.StaticConstraints[key].StaticR1CS)
 		inputConstraintCount := cs.StaticConstraints[key].InputConstraintsThreshold
 		// constraintPos - count is the start constraint of the inputs
-		inputConstraints := cs.Constraints[constraintPos-count : constraintPos-count+inputConstraintCount]
+		inputConstraints := make([]constraint.R1C, inputConstraintCount)
+		copy(inputConstraints, cs.Constraints[constraintPos-count:constraintPos-count+inputConstraintCount])
 		shift := nbVariables - cs.StaticConstraints[key].NbVariables
 		input := constraint.NewLazyInputs(key, inputConstraints, constraintPos-count, count, len(expressions), shift)
 		cs.LazyCons = append(cs.LazyCons, input)

--- a/constraint/bw6-633/r1cs.go
+++ b/constraint/bw6-633/r1cs.go
@@ -103,7 +103,8 @@ func (cs *R1CS) AddStaticConstraints(key string, constraintPos int, finished boo
 		count := len(cs.StaticConstraints[key].StaticR1CS)
 		inputConstraintCount := cs.StaticConstraints[key].InputConstraintsThreshold
 		// constraintPos - count is the start constraint of the inputs
-		inputConstraints := cs.Constraints[constraintPos-count : constraintPos-count+inputConstraintCount]
+		inputConstraints := make([]constraint.R1C, inputConstraintCount)
+		copy(inputConstraints, cs.Constraints[constraintPos-count:constraintPos-count+inputConstraintCount])
 		shift := nbVariables - cs.StaticConstraints[key].NbVariables
 		input := constraint.NewLazyInputs(key, inputConstraints, constraintPos-count, count, len(expressions), shift)
 		cs.LazyCons = append(cs.LazyCons, input)

--- a/constraint/bw6-761/r1cs.go
+++ b/constraint/bw6-761/r1cs.go
@@ -103,7 +103,8 @@ func (cs *R1CS) AddStaticConstraints(key string, constraintPos int, finished boo
 		count := len(cs.StaticConstraints[key].StaticR1CS)
 		inputConstraintCount := cs.StaticConstraints[key].InputConstraintsThreshold
 		// constraintPos - count is the start constraint of the inputs
-		inputConstraints := cs.Constraints[constraintPos-count : constraintPos-count+inputConstraintCount]
+		inputConstraints := make([]constraint.R1C, inputConstraintCount)
+		copy(inputConstraints, cs.Constraints[constraintPos-count:constraintPos-count+inputConstraintCount])
 		shift := nbVariables - cs.StaticConstraints[key].NbVariables
 		input := constraint.NewLazyInputs(key, inputConstraints, constraintPos-count, count, len(expressions), shift)
 		cs.LazyCons = append(cs.LazyCons, input)

--- a/constraint/tinyfield/r1cs.go
+++ b/constraint/tinyfield/r1cs.go
@@ -103,7 +103,8 @@ func (cs *R1CS) AddStaticConstraints(key string, constraintPos int, finished boo
 		count := len(cs.StaticConstraints[key].StaticR1CS)
 		inputConstraintCount := cs.StaticConstraints[key].InputConstraintsThreshold
 		// constraintPos - count is the start constraint of the inputs
-		inputConstraints := cs.Constraints[constraintPos-count : constraintPos-count+inputConstraintCount]
+		inputConstraints := make([]constraint.R1C, inputConstraintCount)
+		copy(inputConstraints, cs.Constraints[constraintPos-count:constraintPos-count+inputConstraintCount])
 		shift := nbVariables - cs.StaticConstraints[key].NbVariables
 		input := constraint.NewLazyInputs(key, inputConstraints, constraintPos-count, count, len(expressions), shift)
 		cs.LazyCons = append(cs.LazyCons, input)

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -85,7 +85,8 @@ func (cs *R1CS) AddStaticConstraints(key string, constraintPos int, finished boo
 		count := len(cs.StaticConstraints[key].StaticR1CS)
 		inputConstraintCount := cs.StaticConstraints[key].InputConstraintsThreshold
 		// constraintPos - count is the start constraint of the inputs
-		inputConstraints := cs.Constraints[constraintPos-count : constraintPos-count+inputConstraintCount]
+		inputConstraints := make([]constraint.R1C, inputConstraintCount)
+		copy(inputConstraints, cs.Constraints[constraintPos-count:constraintPos-count+inputConstraintCount])
 		shift := nbVariables - cs.StaticConstraints[key].NbVariables
 		input := constraint.NewLazyInputs(key, inputConstraints, constraintPos-count, count, len(expressions), shift)
 		cs.LazyCons = append(cs.LazyCons, input)


### PR DESCRIPTION
Fix copy constraints

unfortunatly, the slice copy has caused the memory issues, we should set a max capacity before copying in.