### PR TITLE
Offload debug info in r1cs Load

### DIFF
--- a/constraint/bls12-377/r1cs.go
+++ b/constraint/bls12-377/r1cs.go
@@ -975,12 +975,16 @@ func (cs *R1CS) LoadFromSplitBinaryConcurrent(session string, N, batchSize, NCor
 					cs.R1CSCore.System.GnarkVersion = cs2.R1CSCore.System.GnarkVersion
 					cs.R1CSCore.System.ScalarField = cs2.R1CSCore.System.ScalarField
 					cs.R1CSCore.System.NbInternalVariables = cs2.R1CSCore.System.NbInternalVariables
-					cs.R1CSCore.System.Public = cs2.R1CSCore.System.Public           // Todo
-					cs.R1CSCore.System.Secret = cs2.R1CSCore.System.Secret           // Todo
-					cs.R1CSCore.System.Logs = cs2.R1CSCore.System.Logs               // Todo
-					cs.R1CSCore.System.DebugInfo = cs2.R1CSCore.System.DebugInfo     // Todo
-					cs.R1CSCore.System.SymbolTable = cs2.R1CSCore.System.SymbolTable // Todo
-					cs.R1CSCore.System.MDebug = cs2.R1CSCore.System.MDebug           // Todo
+					cs.R1CSCore.System.Public = make([]string, len(cs2.R1CSCore.System.Public))
+					cs.R1CSCore.System.Secret = make([]string, len(cs2.R1CSCore.System.Secret))
+					if _, ok := os.LookupEnv("GNARK_DEBUG_INFO"); ok {
+						cs.R1CSCore.System.Public = cs2.R1CSCore.System.Public
+						cs.R1CSCore.System.Secret = cs2.R1CSCore.System.Secret
+						cs.R1CSCore.System.Logs = cs2.R1CSCore.System.Logs
+						cs.R1CSCore.System.DebugInfo = cs2.R1CSCore.System.DebugInfo
+						cs.R1CSCore.System.SymbolTable = cs2.R1CSCore.System.SymbolTable
+						cs.R1CSCore.System.MDebug = cs2.R1CSCore.System.MDebug
+					}
 
 					cs.R1CSCore.System.NbHintFnWires = cs2.R1CSCore.System.NbHintFnWires
 					cs.R1CSCore.System.NbHintFnInputs = cs2.R1CSCore.System.NbHintFnInputs

--- a/constraint/bls12-381/r1cs.go
+++ b/constraint/bls12-381/r1cs.go
@@ -975,12 +975,16 @@ func (cs *R1CS) LoadFromSplitBinaryConcurrent(session string, N, batchSize, NCor
 					cs.R1CSCore.System.GnarkVersion = cs2.R1CSCore.System.GnarkVersion
 					cs.R1CSCore.System.ScalarField = cs2.R1CSCore.System.ScalarField
 					cs.R1CSCore.System.NbInternalVariables = cs2.R1CSCore.System.NbInternalVariables
-					cs.R1CSCore.System.Public = cs2.R1CSCore.System.Public           // Todo
-					cs.R1CSCore.System.Secret = cs2.R1CSCore.System.Secret           // Todo
-					cs.R1CSCore.System.Logs = cs2.R1CSCore.System.Logs               // Todo
-					cs.R1CSCore.System.DebugInfo = cs2.R1CSCore.System.DebugInfo     // Todo
-					cs.R1CSCore.System.SymbolTable = cs2.R1CSCore.System.SymbolTable // Todo
-					cs.R1CSCore.System.MDebug = cs2.R1CSCore.System.MDebug           // Todo
+					cs.R1CSCore.System.Public = make([]string, len(cs2.R1CSCore.System.Public))
+					cs.R1CSCore.System.Secret = make([]string, len(cs2.R1CSCore.System.Secret))
+					if _, ok := os.LookupEnv("GNARK_DEBUG_INFO"); ok {
+						cs.R1CSCore.System.Public = cs2.R1CSCore.System.Public
+						cs.R1CSCore.System.Secret = cs2.R1CSCore.System.Secret
+						cs.R1CSCore.System.Logs = cs2.R1CSCore.System.Logs
+						cs.R1CSCore.System.DebugInfo = cs2.R1CSCore.System.DebugInfo
+						cs.R1CSCore.System.SymbolTable = cs2.R1CSCore.System.SymbolTable
+						cs.R1CSCore.System.MDebug = cs2.R1CSCore.System.MDebug
+					}
 
 					cs.R1CSCore.System.NbHintFnWires = cs2.R1CSCore.System.NbHintFnWires
 					cs.R1CSCore.System.NbHintFnInputs = cs2.R1CSCore.System.NbHintFnInputs

--- a/constraint/bls24-315/r1cs.go
+++ b/constraint/bls24-315/r1cs.go
@@ -975,12 +975,16 @@ func (cs *R1CS) LoadFromSplitBinaryConcurrent(session string, N, batchSize, NCor
 					cs.R1CSCore.System.GnarkVersion = cs2.R1CSCore.System.GnarkVersion
 					cs.R1CSCore.System.ScalarField = cs2.R1CSCore.System.ScalarField
 					cs.R1CSCore.System.NbInternalVariables = cs2.R1CSCore.System.NbInternalVariables
-					cs.R1CSCore.System.Public = cs2.R1CSCore.System.Public           // Todo
-					cs.R1CSCore.System.Secret = cs2.R1CSCore.System.Secret           // Todo
-					cs.R1CSCore.System.Logs = cs2.R1CSCore.System.Logs               // Todo
-					cs.R1CSCore.System.DebugInfo = cs2.R1CSCore.System.DebugInfo     // Todo
-					cs.R1CSCore.System.SymbolTable = cs2.R1CSCore.System.SymbolTable // Todo
-					cs.R1CSCore.System.MDebug = cs2.R1CSCore.System.MDebug           // Todo
+					cs.R1CSCore.System.Public = make([]string, len(cs2.R1CSCore.System.Public))
+					cs.R1CSCore.System.Secret = make([]string, len(cs2.R1CSCore.System.Secret))
+					if _, ok := os.LookupEnv("GNARK_DEBUG_INFO"); ok {
+						cs.R1CSCore.System.Public = cs2.R1CSCore.System.Public
+						cs.R1CSCore.System.Secret = cs2.R1CSCore.System.Secret
+						cs.R1CSCore.System.Logs = cs2.R1CSCore.System.Logs
+						cs.R1CSCore.System.DebugInfo = cs2.R1CSCore.System.DebugInfo
+						cs.R1CSCore.System.SymbolTable = cs2.R1CSCore.System.SymbolTable
+						cs.R1CSCore.System.MDebug = cs2.R1CSCore.System.MDebug
+					}
 
 					cs.R1CSCore.System.NbHintFnWires = cs2.R1CSCore.System.NbHintFnWires
 					cs.R1CSCore.System.NbHintFnInputs = cs2.R1CSCore.System.NbHintFnInputs

--- a/constraint/bls24-317/r1cs.go
+++ b/constraint/bls24-317/r1cs.go
@@ -975,12 +975,16 @@ func (cs *R1CS) LoadFromSplitBinaryConcurrent(session string, N, batchSize, NCor
 					cs.R1CSCore.System.GnarkVersion = cs2.R1CSCore.System.GnarkVersion
 					cs.R1CSCore.System.ScalarField = cs2.R1CSCore.System.ScalarField
 					cs.R1CSCore.System.NbInternalVariables = cs2.R1CSCore.System.NbInternalVariables
-					cs.R1CSCore.System.Public = cs2.R1CSCore.System.Public           // Todo
-					cs.R1CSCore.System.Secret = cs2.R1CSCore.System.Secret           // Todo
-					cs.R1CSCore.System.Logs = cs2.R1CSCore.System.Logs               // Todo
-					cs.R1CSCore.System.DebugInfo = cs2.R1CSCore.System.DebugInfo     // Todo
-					cs.R1CSCore.System.SymbolTable = cs2.R1CSCore.System.SymbolTable // Todo
-					cs.R1CSCore.System.MDebug = cs2.R1CSCore.System.MDebug           // Todo
+					cs.R1CSCore.System.Public = make([]string, len(cs2.R1CSCore.System.Public))
+					cs.R1CSCore.System.Secret = make([]string, len(cs2.R1CSCore.System.Secret))
+					if _, ok := os.LookupEnv("GNARK_DEBUG_INFO"); ok {
+						cs.R1CSCore.System.Public = cs2.R1CSCore.System.Public
+						cs.R1CSCore.System.Secret = cs2.R1CSCore.System.Secret
+						cs.R1CSCore.System.Logs = cs2.R1CSCore.System.Logs
+						cs.R1CSCore.System.DebugInfo = cs2.R1CSCore.System.DebugInfo
+						cs.R1CSCore.System.SymbolTable = cs2.R1CSCore.System.SymbolTable
+						cs.R1CSCore.System.MDebug = cs2.R1CSCore.System.MDebug
+					}
 
 					cs.R1CSCore.System.NbHintFnWires = cs2.R1CSCore.System.NbHintFnWires
 					cs.R1CSCore.System.NbHintFnInputs = cs2.R1CSCore.System.NbHintFnInputs

--- a/constraint/bn254/r1cs.go
+++ b/constraint/bn254/r1cs.go
@@ -975,12 +975,16 @@ func (cs *R1CS) LoadFromSplitBinaryConcurrent(session string, N, batchSize, NCor
 					cs.R1CSCore.System.GnarkVersion = cs2.R1CSCore.System.GnarkVersion
 					cs.R1CSCore.System.ScalarField = cs2.R1CSCore.System.ScalarField
 					cs.R1CSCore.System.NbInternalVariables = cs2.R1CSCore.System.NbInternalVariables
-					cs.R1CSCore.System.Public = cs2.R1CSCore.System.Public           // Todo
-					cs.R1CSCore.System.Secret = cs2.R1CSCore.System.Secret           // Todo
-					cs.R1CSCore.System.Logs = cs2.R1CSCore.System.Logs               // Todo
-					cs.R1CSCore.System.DebugInfo = cs2.R1CSCore.System.DebugInfo     // Todo
-					cs.R1CSCore.System.SymbolTable = cs2.R1CSCore.System.SymbolTable // Todo
-					cs.R1CSCore.System.MDebug = cs2.R1CSCore.System.MDebug           // Todo
+					cs.R1CSCore.System.Public = make([]string, len(cs2.R1CSCore.System.Public))
+					cs.R1CSCore.System.Secret = make([]string, len(cs2.R1CSCore.System.Secret))
+					if _, ok := os.LookupEnv("GNARK_DEBUG_INFO"); ok {
+						cs.R1CSCore.System.Public = cs2.R1CSCore.System.Public
+						cs.R1CSCore.System.Secret = cs2.R1CSCore.System.Secret
+						cs.R1CSCore.System.Logs = cs2.R1CSCore.System.Logs
+						cs.R1CSCore.System.DebugInfo = cs2.R1CSCore.System.DebugInfo
+						cs.R1CSCore.System.SymbolTable = cs2.R1CSCore.System.SymbolTable
+						cs.R1CSCore.System.MDebug = cs2.R1CSCore.System.MDebug
+					}
 
 					cs.R1CSCore.System.NbHintFnWires = cs2.R1CSCore.System.NbHintFnWires
 					cs.R1CSCore.System.NbHintFnInputs = cs2.R1CSCore.System.NbHintFnInputs

--- a/constraint/bw6-633/r1cs.go
+++ b/constraint/bw6-633/r1cs.go
@@ -975,12 +975,16 @@ func (cs *R1CS) LoadFromSplitBinaryConcurrent(session string, N, batchSize, NCor
 					cs.R1CSCore.System.GnarkVersion = cs2.R1CSCore.System.GnarkVersion
 					cs.R1CSCore.System.ScalarField = cs2.R1CSCore.System.ScalarField
 					cs.R1CSCore.System.NbInternalVariables = cs2.R1CSCore.System.NbInternalVariables
-					cs.R1CSCore.System.Public = cs2.R1CSCore.System.Public           // Todo
-					cs.R1CSCore.System.Secret = cs2.R1CSCore.System.Secret           // Todo
-					cs.R1CSCore.System.Logs = cs2.R1CSCore.System.Logs               // Todo
-					cs.R1CSCore.System.DebugInfo = cs2.R1CSCore.System.DebugInfo     // Todo
-					cs.R1CSCore.System.SymbolTable = cs2.R1CSCore.System.SymbolTable // Todo
-					cs.R1CSCore.System.MDebug = cs2.R1CSCore.System.MDebug           // Todo
+					cs.R1CSCore.System.Public = make([]string, len(cs2.R1CSCore.System.Public))
+					cs.R1CSCore.System.Secret = make([]string, len(cs2.R1CSCore.System.Secret))
+					if _, ok := os.LookupEnv("GNARK_DEBUG_INFO"); ok {
+						cs.R1CSCore.System.Public = cs2.R1CSCore.System.Public
+						cs.R1CSCore.System.Secret = cs2.R1CSCore.System.Secret
+						cs.R1CSCore.System.Logs = cs2.R1CSCore.System.Logs
+						cs.R1CSCore.System.DebugInfo = cs2.R1CSCore.System.DebugInfo
+						cs.R1CSCore.System.SymbolTable = cs2.R1CSCore.System.SymbolTable
+						cs.R1CSCore.System.MDebug = cs2.R1CSCore.System.MDebug
+					}
 
 					cs.R1CSCore.System.NbHintFnWires = cs2.R1CSCore.System.NbHintFnWires
 					cs.R1CSCore.System.NbHintFnInputs = cs2.R1CSCore.System.NbHintFnInputs

--- a/constraint/bw6-761/r1cs.go
+++ b/constraint/bw6-761/r1cs.go
@@ -975,12 +975,16 @@ func (cs *R1CS) LoadFromSplitBinaryConcurrent(session string, N, batchSize, NCor
 					cs.R1CSCore.System.GnarkVersion = cs2.R1CSCore.System.GnarkVersion
 					cs.R1CSCore.System.ScalarField = cs2.R1CSCore.System.ScalarField
 					cs.R1CSCore.System.NbInternalVariables = cs2.R1CSCore.System.NbInternalVariables
-					cs.R1CSCore.System.Public = cs2.R1CSCore.System.Public           // Todo
-					cs.R1CSCore.System.Secret = cs2.R1CSCore.System.Secret           // Todo
-					cs.R1CSCore.System.Logs = cs2.R1CSCore.System.Logs               // Todo
-					cs.R1CSCore.System.DebugInfo = cs2.R1CSCore.System.DebugInfo     // Todo
-					cs.R1CSCore.System.SymbolTable = cs2.R1CSCore.System.SymbolTable // Todo
-					cs.R1CSCore.System.MDebug = cs2.R1CSCore.System.MDebug           // Todo
+					cs.R1CSCore.System.Public = make([]string, len(cs2.R1CSCore.System.Public))
+					cs.R1CSCore.System.Secret = make([]string, len(cs2.R1CSCore.System.Secret))
+					if _, ok := os.LookupEnv("GNARK_DEBUG_INFO"); ok {
+						cs.R1CSCore.System.Public = cs2.R1CSCore.System.Public
+						cs.R1CSCore.System.Secret = cs2.R1CSCore.System.Secret
+						cs.R1CSCore.System.Logs = cs2.R1CSCore.System.Logs
+						cs.R1CSCore.System.DebugInfo = cs2.R1CSCore.System.DebugInfo
+						cs.R1CSCore.System.SymbolTable = cs2.R1CSCore.System.SymbolTable
+						cs.R1CSCore.System.MDebug = cs2.R1CSCore.System.MDebug
+					}
 
 					cs.R1CSCore.System.NbHintFnWires = cs2.R1CSCore.System.NbHintFnWires
 					cs.R1CSCore.System.NbHintFnInputs = cs2.R1CSCore.System.NbHintFnInputs

--- a/constraint/tinyfield/r1cs.go
+++ b/constraint/tinyfield/r1cs.go
@@ -975,12 +975,16 @@ func (cs *R1CS) LoadFromSplitBinaryConcurrent(session string, N, batchSize, NCor
 					cs.R1CSCore.System.GnarkVersion = cs2.R1CSCore.System.GnarkVersion
 					cs.R1CSCore.System.ScalarField = cs2.R1CSCore.System.ScalarField
 					cs.R1CSCore.System.NbInternalVariables = cs2.R1CSCore.System.NbInternalVariables
-					cs.R1CSCore.System.Public = cs2.R1CSCore.System.Public           // Todo
-					cs.R1CSCore.System.Secret = cs2.R1CSCore.System.Secret           // Todo
-					cs.R1CSCore.System.Logs = cs2.R1CSCore.System.Logs               // Todo
-					cs.R1CSCore.System.DebugInfo = cs2.R1CSCore.System.DebugInfo     // Todo
-					cs.R1CSCore.System.SymbolTable = cs2.R1CSCore.System.SymbolTable // Todo
-					cs.R1CSCore.System.MDebug = cs2.R1CSCore.System.MDebug           // Todo
+					cs.R1CSCore.System.Public = make([]string, len(cs2.R1CSCore.System.Public))
+					cs.R1CSCore.System.Secret = make([]string, len(cs2.R1CSCore.System.Secret))
+					if _, ok := os.LookupEnv("GNARK_DEBUG_INFO"); ok {
+						cs.R1CSCore.System.Public = cs2.R1CSCore.System.Public
+						cs.R1CSCore.System.Secret = cs2.R1CSCore.System.Secret
+						cs.R1CSCore.System.Logs = cs2.R1CSCore.System.Logs
+						cs.R1CSCore.System.DebugInfo = cs2.R1CSCore.System.DebugInfo
+						cs.R1CSCore.System.SymbolTable = cs2.R1CSCore.System.SymbolTable
+						cs.R1CSCore.System.MDebug = cs2.R1CSCore.System.MDebug
+					}
 
 					cs.R1CSCore.System.NbHintFnWires = cs2.R1CSCore.System.NbHintFnWires
 					cs.R1CSCore.System.NbHintFnInputs = cs2.R1CSCore.System.NbHintFnInputs

--- a/internal/generator/backend/template/representations/r1cs.go.tmpl
+++ b/internal/generator/backend/template/representations/r1cs.go.tmpl
@@ -958,12 +958,16 @@ func (cs *R1CS) LoadFromSplitBinaryConcurrent(session string, N, batchSize, NCor
 					cs.R1CSCore.System.GnarkVersion = cs2.R1CSCore.System.GnarkVersion
 					cs.R1CSCore.System.ScalarField = cs2.R1CSCore.System.ScalarField
 					cs.R1CSCore.System.NbInternalVariables = cs2.R1CSCore.System.NbInternalVariables
-					cs.R1CSCore.System.Public = cs2.R1CSCore.System.Public           // Todo
-					cs.R1CSCore.System.Secret = cs2.R1CSCore.System.Secret           // Todo
-					cs.R1CSCore.System.Logs = cs2.R1CSCore.System.Logs               // Todo
-					cs.R1CSCore.System.DebugInfo = cs2.R1CSCore.System.DebugInfo     // Todo
-					cs.R1CSCore.System.SymbolTable = cs2.R1CSCore.System.SymbolTable // Todo
-					cs.R1CSCore.System.MDebug = cs2.R1CSCore.System.MDebug           // Todo
+					cs.R1CSCore.System.Public = make([]string, len(cs2.R1CSCore.System.Public))
+					cs.R1CSCore.System.Secret = make([]string, len(cs2.R1CSCore.System.Secret))
+					if _, ok := os.LookupEnv("GNARK_DEBUG_INFO"); ok {
+						cs.R1CSCore.System.Public = cs2.R1CSCore.System.Public
+						cs.R1CSCore.System.Secret = cs2.R1CSCore.System.Secret
+						cs.R1CSCore.System.Logs = cs2.R1CSCore.System.Logs
+						cs.R1CSCore.System.DebugInfo = cs2.R1CSCore.System.DebugInfo
+						cs.R1CSCore.System.SymbolTable = cs2.R1CSCore.System.SymbolTable
+						cs.R1CSCore.System.MDebug = cs2.R1CSCore.System.MDebug
+					}
 
 					cs.R1CSCore.System.NbHintFnWires = cs2.R1CSCore.System.NbHintFnWires
 					cs.R1CSCore.System.NbHintFnInputs = cs2.R1CSCore.System.NbHintFnInputs


### PR DESCRIPTION
Offload debug info in r1cs when Load. The debug info can still be loaded if environment variable GNARK_DEBUG_INFO is set.